### PR TITLE
Upgrade to Android Gradle Plugin 2.3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ def git = org.ajoberstar.grgit.Grgit.open(file('..'))
 ext.revision = git.head().getAbbreviatedId(7)
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "25.0.3"
 
     externalNativeBuild {
         /*ndkBuild {
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         applicationId "org.libsdl.openxcom"
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 28
 
         externalNativeBuild {
             /*ndkBuild {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ ext.revision = git.head().getAbbreviatedId(7)
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "28.0.3"
 
     externalNativeBuild {
         /*ndkBuild {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.0.2'
+    gradleVersion = '4.10.3'
 }
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.2'
+    gradleVersion = '4.0.2'
 }
 
 buildscript {
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'org.ajoberstar:grgit:1.1.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri Feb 15 18:52:55 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
Upgrade to the lastest stable version of Android Gradle Plugin 2.x and its companions.
Plugin version/	Required Gradle version/	Build Tools
2.3.0+		3.3+ (4.0.2)			25.0.3
I verified Android Studio 3.3.1 + Windows 7 + NDK r15c with output app-debug.apk, app-release-unsigned.apk and app-release.apk.

Reference:
[Android Gradle plugin release notes](https://developer.android.google.cn/studio/releases/gradle-plugin)
[Gradle Distributions](https://services.gradle.org/distributions/)
[SDK Build Tools release notes](https://developer.android.google.cn/studio/releases/build-tools)
[NDK Archives](https://developer.android.google.cn/ndk/downloads/older_releases)

Download:
[Android Gradle Plugin 2.3.3](https://jcenter.bintray.com/com/android/tools/build/builder/2.3.3/)
[Gradle 4.0.2](https://services.gradle.org/distributions/gradle-4.0.2-all.zip)
[Android SDK build tools 25.0.3](https://dl.google.com/android/repository/build-tools_r25.0.3-windows.zip)
[Android NDK r15c](https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip)
