### PR TITLE
Upgrade to Gradle 7.x and NDK r23b

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,7 @@ android {
         includeInBundle true
     }
     buildToolsVersion '30.0.2'
-    ndkVersion '18.1.5063045'
+    ndkVersion '23.1.7779620'
 }
 
 def getFolder(resource) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,7 @@ task packBin(description: 'Update data files.') {
             archiveFileName = index.toString() + '_' + res + '.zip'
             destinationDirectory = file('src/main/assets')
             from getFolder(res)
+            into res
         }
         dependsOn(tasks.getByName('zip' + res))
         ++index

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+    compileOptions {
+        sourceCompatibility revision
+        targetCompatibility revision
+    }
+    dependenciesInfo {
+        includeInApk true
+        includeInBundle true
+    }
+    buildToolsVersion '30.0.2'
+    ndkVersion '18.1.5063045'
 }
 
 def getFolder(resource) {
@@ -98,7 +108,6 @@ task packBin(description: 'Update data files.') {
         zip.archiveName = index.toString() + "_" + res + '.zip'
         zip.from getFolder(res)
         zip.into res
-        zip.execute()
         index++;
     }
     def zipTranslations = task("zipTranslations", type: Zip)
@@ -106,7 +115,6 @@ task packBin(description: 'Update data files.') {
     zipTranslations.destinationDir = file('src/main/assets')
     zipTranslations.archiveName = '7_translations.zip'
     zipTranslations.from getFolder('translations/output')
-    zipTranslations.execute()
 }
 
 gradle.projectsEvaluated {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,26 +95,29 @@ android {
 }
 
 def getFolder(resource) {
-    def binDir = file('src/main/jni/OpenXcom/bin/' + resource);
-    return binDir;
+    def binDir = file('src/main/jni/OpenXcom/bin/' + resource)
+    return binDir
 }
 
 task packBin(description: 'Update data files.') {
-    def index = 0;
+    def index = 0
     ['common', 'standard', 'UFO', 'TFTD'].each { String res ->
-        def zip = task("zip" + res, type: Zip)
-        zip.doFirst { println('Packing ' + res + '...') }
-        zip.destinationDir = file('src/main/assets')
-        zip.archiveName = index.toString() + "_" + res + '.zip'
-        zip.from getFolder(res)
-        zip.into res
-        index++;
+        tasks.register('zip' + res, Zip) {
+            doFirst { println('Packing ' + res + '...') }
+            archiveFileName = index.toString() + '_' + res + '.zip'
+            destinationDirectory = file('src/main/assets')
+            from getFolder(res)
+        }
+        dependsOn(tasks.getByName('zip' + res))
+        ++index
     }
-    def zipTranslations = task("zipTranslations", type: Zip)
-    zipTranslations.doFirst { println('Packing translations...' )}
-    zipTranslations.destinationDir = file('src/main/assets')
-    zipTranslations.archiveName = '7_translations.zip'
-    zipTranslations.from getFolder('translations/output')
+    tasks.register('zipTranslations', Zip) {
+        doFirst { println('Packing translations...' ) }
+        archiveFileName = '7_translations.zip'
+        destinationDirectory = file('src/main/assets')
+        from getFolder('translations/output')
+    }
+    dependsOn(tasks.getByName('zipTranslations'))
 }
 
 gradle.projectsEvaluated {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,8 +83,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility revision
-        targetCompatibility revision
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     dependenciesInfo {
         includeInApk true

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.10.3'
+wrapper {
+    gradleVersion = '7.3'
 }
 
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath 'org.ajoberstar:grgit:1.1.0'
     }
 }
@@ -18,6 +18,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip


### PR DESCRIPTION
Upgrade to Android Gradle Plugin 7.0.3, Gradle 7.3, Android SDK Build Tools 30.0.2, set ndkVersion to 23.1.7779620 (r23b) and Java compatibility to VERSION_1_8.

The additions in app/build.gradle were done by Android Studio "File->Project Structure" dialog.

I built an APK release with android-studio-2020.3.1.25-windows on Windows 10. It was tested on my Android 7.0 (Samsung Galaxy S6 edge+) and Android 11 (Vivo X70 Pro+). Both look good.
![20211119222432](https://user-images.githubusercontent.com/10295404/142638378-bd7ff1bf-2814-4e51-964f-833b53577ebc.jpg)

FYI:
[Android Gradle plugin release notes](https://developer.android.google.cn/studio/releases/gradle-plugin#updating-plugin)
[Gradle Distributions](https://services.gradle.org/distributions/)
[NDK Downloads](https://developer.android.google.cn/ndk/downloads)
[Cannot add task 'wrapper' as a task with that name already exists](https://stackoverflow.com/questions/53709282/cannot-add-task-wrapper-as-a-task-with-that-name-already-exists)
[How to specify source and target compatibility in Java module?](https://stackoverflow.com/questions/41017544/how-to-specify-source-and-target-compatibility-in-java-module)